### PR TITLE
More concise package description

### DIFF
--- a/tao-theme-pkg.el
+++ b/tao-theme-pkg.el
@@ -1,4 +1,4 @@
 (define-package
   "tao-theme"
   "0.1.1"
-  "Tao, light & dark themes for Emacs with greyscale palettes generated from the golden mean.")
+  "Light & dark themes with greyscale palettes generated from the golden mean")


### PR DESCRIPTION
- Remove redundant "for Emacs"
- Remove confusing "Tao,"