### PR TITLE
Add option to disable changing face height

### DIFF
--- a/tao-yinyang-common.el
+++ b/tao-yinyang-common.el
@@ -2,6 +2,19 @@
 
 (require 'cl-lib)
 
+(defgroup tao-theme nil
+  "tao-theme customization options")
+
+(defcustom tao-theme-use-height t
+  "Non-nil means tao-theme is allowed to customize height"
+  :type 'boolean
+  :group 'tao-theme)
+
+(defun tao-theme-height (height)
+  (if tao-theme-use-height
+      height
+    1.0))
+
 (defun tao-theme-golden-grayscale ()
   "Generate a golden mean based greyscale gradient."
   (let (zeta
@@ -113,7 +126,7 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(newsticker-date-face                             ((t (:foreground ,color-13))))
    `(newsticker-default-face                          ((t (:foreground ,color-13))))
    `(newsticker-enclosure-face                        ((t (:foreground ,color-12))))
-   `(newsticker-extra-face                            ((t (:foreground ,color-7 :height 0.8))))
+   `(newsticker-extra-face                            ((t (:foreground ,color-7 :height ,(tao-theme-height 0.8)))))
    `(newsticker-feed-face                             ((t (:foreground ,color-13))))
    `(newsticker-immortal-item-face                    ((t (:foreground ,color-9))))
    `(newsticker-new-item-face                         ((t (:foreground ,color-11))))
@@ -443,9 +456,9 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(jabber-chat-prompt-foreign                       ((t (:foreground ,color-11))))
    `(jabber-activity-face                             ((t (:foreground ,color-11))))
    `(jabber-activity-personal-face                    ((t (:foreground ,color-11))))
-   `(jabber-title-small                               ((t (:height 1.1 :weight bold))))
-   `(jabber-title-medium                              ((t (:height 1.2 :weight bold))))
-   `(jabber-title-large                               ((t (:height 1.3 :weight bold))))
+   `(jabber-title-small                               ((t (:height ,(tao-theme-height 1.1) :weight bold))))
+   `(jabber-title-medium                              ((t (:height ,(tao-theme-height 1.2) :weight bold))))
+   `(jabber-title-large                               ((t (:height ,(tao-theme-height 1.3) :weight bold))))
    ;; ledger-mode
    `(ledger-font-payee-uncleared-face                 ((t (:foreground ,color-9 :weight bold))))
    `(ledger-font-payee-cleared-face                   ((t (:foreground ,color-13 :weight normal))))
@@ -573,15 +586,15 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(org-formula                                      ((t (:foreground ,color-11))))
    `(org-headline-done                                ((t (:foreground ,color-12))))
    `(org-hide                                         ((t (:foreground ,color-3))))
-   `(org-document-title                               ((t (:foreground ,color-12 :height 1.9 :bold t))))
-   `(org-level-1                                      ((t (:foreground ,color-14 :height 1.5))))
-   `(org-level-2                                      ((t (:foreground ,color-10 :height 1.2))))
-   `(org-level-3                                      ((t (:foreground ,color-9 :height 1.1))))
-   `(org-level-4                                      ((t (:foreground ,color-9 :height 1.0))))
-   `(org-level-5                                      ((t (:foreground ,color-9 :height 1.0))))
-   `(org-level-6                                      ((t (:foreground ,color-9 :height 1.0))))
-   `(org-level-7                                      ((t (:foreground ,color-9 :height 1.0))))
-   `(org-level-8                                      ((t (:foreground ,color-8 :height 1.0))))
+   `(org-document-title                               ((t (:foreground ,color-12 :height ,(tao-theme-height 1.9) :bold t))))
+   `(org-level-1                                      ((t (:foreground ,color-14 :height ,(tao-theme-height 1.5)))))
+   `(org-level-2                                      ((t (:foreground ,color-10 :height ,(tao-theme-height 1.2)))))
+   `(org-level-3                                      ((t (:foreground ,color-9 :height ,(tao-theme-height 1.1)))))
+   `(org-level-4                                      ((t (:foreground ,color-9 :height ,(tao-theme-height 1.0)))))
+   `(org-level-5                                      ((t (:foreground ,color-9 :height ,(tao-theme-height 1.0)))))
+   `(org-level-6                                      ((t (:foreground ,color-9 :height ,(tao-theme-height 1.0)))))
+   `(org-level-7                                      ((t (:foreground ,color-9 :height ,(tao-theme-height 1.0)))))
+   `(org-level-8                                      ((t (:foreground ,color-8 :height ,(tao-theme-height 1.0)))))
    `(org-link                                         ((t (:foreground ,color-11 :underline t))))
    `(org-scheduled                                    ((t (:foreground ,color-13))))
    `(org-scheduled-previously                         ((t (:foreground ,color-10))))
@@ -601,9 +614,9 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(org-mode-line-clock-overrun                      ((t (:foreground ,color-5 :background ,color-9))))
    `(org-ellipsis                                     ((t (:foreground ,color-12 :underline t))))
    `(org-footnote                                     ((t (:foreground ,color-12 :underline t))))
-   `(org-meta-line                                    ((t (:foreground ,color-8 :height 1.0))))
-   `(org-block-background                             ((t (:background ,color-4 :height 1.0))))
-   `(org-block                                        ((t (:foreground ,color-7 :height 1.0))))
+   `(org-meta-line                                    ((t (:foreground ,color-8 :height ,(tao-theme-height 1.0)))))
+   `(org-block-background                             ((t (:background ,color-4 :height ,(tao-theme-height 1.0)))))
+   `(org-block                                        ((t (:foreground ,color-7 :height ,(tao-theme-height 1.0)))))
 
    ;; outline
    `(outline-1                                        ((t (:foreground ,color-11))))
@@ -836,15 +849,15 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(html-fold-folded-face                            ((t (:foreground ,color-14 :bold t))))
    ;; markdown mode
    `(markdown-header-delimiter-face                   ((t (:weight normal :foreground ,color-6))))
-   `(markdown-header-face-1                           ((t (:inherit markdown-header-face :height 1.5))))
-   `(markdown-header-face-2                           ((t (:inherit markdown-header-face :height 1.3))))
-   `(markdown-header-face-3                           ((t (:inherit markdown-header-face :underline t :height 1.2))))
-   `(markdown-header-face-4                           ((t (:inherit markdown-header-face :underline t :height 1.1))))
+   `(markdown-header-face-1                           ((t (:inherit markdown-header-face :height ,(tao-theme-height 1.5)))))
+   `(markdown-header-face-2                           ((t (:inherit markdown-header-face :height ,(tao-theme-height 1.3)))))
+   `(markdown-header-face-3                           ((t (:inherit markdown-header-face :underline t :height ,(tao-theme-height 1.2)))))
+   `(markdown-header-face-4                           ((t (:inherit markdown-header-face :underline t :height ,(tao-theme-height 1.1)))))
    `(markdown-header-face-5                           ((t (:inherit markdown-header-face :underline t))))
    `(markdown-header-face-6                           ((t (:inherit markdown-header-face :underline t))))
    `(markdown-link-face                               ((t (:underline t :foreground ,color-13))))
    `(markdown-url-face                                ((t (:underline t :foreground ,color-12))))
-   `(markdown-pre-face                                ((t (:foreground ,color-13 :height .8 ))))
+   `(markdown-pre-face                                ((t (:foreground ,color-13 :height ,(tao-theme-height .8) ))))
    `(markdown-bold-face                                ((t (:foreground ,color-8 :bold t ))))
    `(markdown-italic-face                                ((t (:foreground ,color-8 :italic t ))))
    `(markdown-list-face                               ((t (:foreground ,color-12))))


### PR DESCRIPTION
I'm not a huge fan of it changing the face height for certain modes (like org-mode or for Markdown), so this pull request adds an option to control whether tao-theme is allowed to change the face-height.

I haven't tested this extensively, but I believe the change to your `.emacs` file, if you want to modify this option, is to go from:

```elisp
(load-theme 'tao-yin t)
```

to

```elisp
(setq tao-theme-use-height nil)
(load-theme 'tao-yin t)
```

By default, tao-theme will still change the font height like it used to, but now there is a way to disable it, if someone wants.