### PR TITLE
Basic Circe setup

### DIFF
--- a/tao-theme.el
+++ b/tao-theme.el
@@ -1072,6 +1072,13 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(hs-fringe-face                                 ((t (:foreground ,color-12  :background ,color-4))))
    `(custom-variable-tag                            ((t (:foreground ,color-11 :bold t))))
    `(origami-fold-replacement-face                  ((t (:foreground ,color-8 :bold t))))
+   ;; circe
+   `(circe-highlight-nick-face                      ((t (:background ,color-6 :foreground ,color-11 :weight bold))))
+   `(circe-prompt-face                              ((t (:foreground ,color-1 :background ,color-9 :inherit fixed-pitch))))
+   `(circe-server-face                              ((t (:foreground ,color-8 :italic t))))
+   ;; lui
+   `(lui-time-stamp-face                            ((t (:foreground ,color-11 :background ,color-4))))
+   `(lui-button-face                                ((t (:inherit hover-highlight))))
    )
 
   ;; Theme Variables


### PR DESCRIPTION
Hi there,

I use [Circe](https://github.com/jorgenschaefer/circe) and it was missing some customized faces.
Without this patch, faces are blue (server message, timestamp in right column) or cyan (prompt, links, highlights).

Here is a screenshot showcasing the result (with nlinum, without feebleline, the nick's colors are automatically generated by Circe):
<img width="1920" alt="screen shot 2018-09-29 at 00 56 32" src="https://user-images.githubusercontent.com/3048933/46237519-445fdd00-c385-11e8-81e1-6263300c5da3.png">

Thanks for the theme.

Regards.
