### PR TITLE
fix the type of tao-theme-scale-fn

### DIFF
--- a/tao-theme.el
+++ b/tao-theme.el
@@ -77,7 +77,7 @@
 
 (defcustom tao-theme-scale-fn 'tao-theme-golden-scale
   "gen alist of two-digit numbers"
-  :type 'funcall
+  :type 'function
   :group 'tao-theme)
 
 (defun tao-theme-taiji-fn (scale)


### PR DESCRIPTION
By the document of customization: https://www.gnu.org/software/emacs/manual/html_node/elisp/Simple-Types.html#Simple-Types

Here `:type` of `tao-theme-scale-fn` is better as `function`? Otherwise emacs is not able to set this variable by customize page. 