### PR TITLE
Fix file footer for addition to NonGNU ELPA

### DIFF
--- a/tao-theme.el
+++ b/tao-theme.el
@@ -1203,3 +1203,5 @@ Also bind `class' to ((class color) (min-colors 89))."
   )
 
 (provide 'tao-theme)
+
+;;; tao-theme.el ends here

--- a/tao-theme.el
+++ b/tao-theme.el
@@ -10,7 +10,7 @@
 ;;
 ;; URL: http://github.com/11111000000/tao-theme-emacs
 ;;
-;; Version: 1.1.2
+;; Version: 1.1.3
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
(This is a followup to #51.)

When adding the package to NonGNU ELPA, I saw the following error:

```
Search failed: ";;; tao-theme.el ends here"
make: *** [GNUmakefile:21: build/tao-theme] Error 255
```

This PR fixes that, and bumps the version again.

Thanks!