### PR TITLE
Update version number to 1.1.3 uniformally

### DIFF
--- a/tao-theme-pkg.el
+++ b/tao-theme-pkg.el
@@ -1,4 +1,4 @@
 (define-package
   "tao-theme"  
-  "1.1.1"
+  "1.1.3"
   "This package provides two parametrized uncoloured color themes for Emacs: tao-yin and tao-yang.")

--- a/tao-yang-theme.el
+++ b/tao-yang-theme.el
@@ -10,7 +10,7 @@
 ;;
 ;; URL: http://github.com/11111000000/tao-theme-emacs
 ;;
-;; Version: 1.1.1
+;; Version: 1.1.3
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/tao-yin-theme.el
+++ b/tao-yin-theme.el
@@ -10,7 +10,7 @@
 ;;
 ;; URL: http://github.com/11111000000/tao-theme-emacs
 ;;
-;; Version: 1.1.1
+;; Version: 1.1.3
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Version numbers in `*-pkg.el` files weren't aligned to the `;; Version: ` comment in `tao-theme.el` (which `package.el` also likes to inspect).  I aligned them all to `1.1.3` which seems to be the current version.

If you didn't mean for this to happen, please ignore this PR.  Thanks!